### PR TITLE
Fix Pages deploy: install wasi-sdk for WASM C cross-compilation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,7 +39,18 @@ jobs:
             cargo install wasm-bindgen-cli --version 0.2.114
           fi
 
+      - name: Install wasi-sdk
+        run: |
+          WASI_SDK_VERSION=31
+          WASI_SDK_FULL=31.0
+          curl -fsSL "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_FULL}-x86_64-linux.tar.gz" | tar xz
+          echo "WASI_SDK_PATH=$PWD/wasi-sdk-${WASI_SDK_FULL}-x86_64-linux" >> "$GITHUB_ENV"
+
       - name: Build Pages artifact
+        env:
+          CC_wasm32_unknown_unknown: ${{ env.WASI_SDK_PATH }}/bin/clang
+          AR_wasm32_unknown_unknown: ${{ env.WASI_SDK_PATH }}/bin/llvm-ar
+          CFLAGS_wasm32_unknown_unknown: "--target=wasm32-unknown-unknown --sysroot=${{ env.WASI_SDK_PATH }}/share/wasi-sysroot"
         run: ./scripts/build-wasm-demo.sh
 
       - name: Configure Pages


### PR DESCRIPTION
## Summary
- Install wasi-sdk in the Pages CI workflow to provide C sysroot headers for wasm32-unknown-unknown target
- The `webp-lossy` feature (added in #77) requires compiling `libwebp` C code, which needs `inttypes.h` and other standard C headers
- Without wasi-sdk, `cc-rs` fails with `fatal error: 'inttypes.h' file not found`

## Test plan
- [ ] Pages deploy workflow completes successfully
- [ ] WASM demo loads and WebP conversion works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added WebAssembly toolchain configuration to the build pipeline, including wasi-sdk integration and compilation environment variables for enhanced build capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->