### PR TITLE
fix: use wasm32-wasip1 C target for wasi-sdk sysroot header resolution

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -12,7 +13,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: github-pages
+  group: github-pages-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -50,18 +51,21 @@ jobs:
         env:
           CC_wasm32_unknown_unknown: ${{ env.WASI_SDK_PATH }}/bin/clang
           AR_wasm32_unknown_unknown: ${{ env.WASI_SDK_PATH }}/bin/llvm-ar
-          CFLAGS_wasm32_unknown_unknown: "--target=wasm32-unknown-unknown --sysroot=${{ env.WASI_SDK_PATH }}/share/wasi-sysroot"
+          CFLAGS_wasm32_unknown_unknown: "--target=wasm32-wasip1 --sysroot=${{ env.WASI_SDK_PATH }}/share/wasi-sysroot"
         run: ./scripts/build-wasm-demo.sh
 
       - name: Configure Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v4
         with:
           path: web/dist
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build
     environment:


### PR DESCRIPTION
## Summary
- Change CFLAGS C compiler target from `wasm32-unknown-unknown` to `wasm32-wasip1` so wasi-sdk's sysroot headers (`inttypes.h`, `assert.h`, etc.) are found correctly
- Run the Pages build job on PRs (deploy remains main-push only) to validate WASM builds before merging
- Use per-ref concurrency group to avoid PR runs cancelling main deployments

## Root cause
wasi-sdk 31's sysroot has headers under `wasm32-wasip1/`, not `wasm32-unknown-unknown/`. The C compiler's `#include_next <inttypes.h>` failed because the target triple didn't match the sysroot directory structure. The Rust target remains `wasm32-unknown-unknown` — only the C compiler target changes.

## Test plan
- [ ] Verify the "Deploy Pages / build" job passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to support pull request checks with refined concurrency handling.
  * Adjusted deployment conditions to only execute on main branch pushes, preventing unintended deployments.
  * Updated WebAssembly toolchain configuration for enhanced build compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->