### PR TITLE
fix: release workflow aarch64 build and add PR verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,18 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - "Cross.toml"
+      - "Dockerfile.release"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
 
 concurrency:
   group: release-${{ github.ref_name }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -29,6 +37,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Ensure tag matches Cargo.toml version
+        if: github.event_name == 'push'
         run: |
           expected_tag="v$(cargo pkgid | sed -E 's/.*@//')"
           if [ "${GITHUB_REF_NAME}" != "${expected_tag}" ]; then
@@ -39,43 +48,7 @@ jobs:
       - name: Verify publishable package
         run: cargo publish --locked --dry-run
 
-  # ── 2. Publish crate to crates.io ───────────────────────────────────
-  publish-crate:
-    runs-on: ubuntu-latest
-    needs: verify
-    permissions:
-      contents: read
-      id-token: write
-    env:
-      HAS_CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN != '' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
-
-      - name: Authenticate to crates.io with trusted publishing
-        if: env.HAS_CARGO_REGISTRY_TOKEN == 'false'
-        id: crates-auth
-        uses: rust-lang/crates-io-auth-action@v1
-
-      - name: Publish crate with API token
-        if: env.HAS_CARGO_REGISTRY_TOKEN == 'true'
-        run: cargo publish --locked
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-      - name: Publish crate with trusted publishing
-        if: env.HAS_CARGO_REGISTRY_TOKEN == 'false'
-        run: cargo publish --locked
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
-
-  # ── 2b. Build release binaries ──────────────────────────────────────
+  # ── 2. Build release binaries (PR: verify only, tag: full build) ───
   build-binaries:
     needs: verify
     strategy:
@@ -127,6 +100,7 @@ jobs:
         run: ${{ matrix.cross && 'cross' || 'cargo' }} build --release --locked --target ${{ matrix.target }} --features "s3,gcs,azure"
 
       - name: Determine binary path
+        if: startsWith(github.ref, 'refs/tags/')
         id: bin
         shell: bash
         run: |
@@ -139,22 +113,22 @@ jobs:
           fi
 
       - name: Strip binary (Linux/macOS)
-        if: matrix.os != 'windows-latest' && !matrix.cross
+        if: startsWith(github.ref, 'refs/tags/') && matrix.os != 'windows-latest' && !matrix.cross
         run: strip ${{ steps.bin.outputs.path }}
 
       - name: Strip binary (cross aarch64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        if: startsWith(github.ref, 'refs/tags/') && matrix.target == 'aarch64-unknown-linux-gnu'
         run: aarch64-linux-gnu-strip ${{ steps.bin.outputs.path }}
 
       - name: Create archive (tar.gz)
-        if: matrix.archive == 'tar.gz'
+        if: startsWith(github.ref, 'refs/tags/') && matrix.archive == 'tar.gz'
         run: |
           archive_name="truss-${GITHUB_REF_NAME}-${{ matrix.target }}.tar.gz"
           tar czf "${archive_name}" -C "$(dirname ${{ steps.bin.outputs.path }})" ${{ steps.bin.outputs.name }}
           echo "ARCHIVE=${archive_name}" >> "$GITHUB_ENV"
 
       - name: Create archive (zip)
-        if: matrix.archive == 'zip'
+        if: startsWith(github.ref, 'refs/tags/') && matrix.archive == 'zip'
         shell: bash
         run: |
           archive_name="truss-${GITHUB_REF_NAME}-${{ matrix.target }}.zip"
@@ -162,6 +136,7 @@ jobs:
           echo "ARCHIVE=${archive_name}" >> "$GITHUB_ENV"
 
       - name: Generate checksum
+        if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
@@ -171,6 +146,7 @@ jobs:
           fi
 
       - name: Upload artifacts
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v7
         with:
           name: binary-${{ matrix.target }}
@@ -178,8 +154,46 @@ jobs:
             ${{ env.ARCHIVE }}
             ${{ env.ARCHIVE }}.sha256
 
-  # ── 3. Build & push container image ─────────────────────────────────
+  # ── 3. Publish crate to crates.io (tag push only) ──────────────────
+  publish-crate:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: verify
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      HAS_CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN != '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Authenticate to crates.io with trusted publishing
+        if: env.HAS_CARGO_REGISTRY_TOKEN == 'false'
+        id: crates-auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish crate with API token
+        if: env.HAS_CARGO_REGISTRY_TOKEN == 'true'
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish crate with trusted publishing
+        if: env.HAS_CARGO_REGISTRY_TOKEN == 'false'
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
+
+  # ── 4. Build & push container image (tag push only) ────────────────
   publish-container:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: [publish-crate, build-binaries]
     permissions:
@@ -271,8 +285,9 @@ jobs:
             "${IMAGE}:${{ github.ref_name }}-amd64" \
             "${IMAGE}:${{ github.ref_name }}-arm64"
 
-  # ── 4. Create GitHub Release ────────────────────────────────────────
+  # ── 5. Create GitHub Release (tag push only) ───────────────────────
   create-release:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: [publish-container, build-binaries]
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.7.2
+
+### Fixed
+
+- Fix aarch64 cross-compilation failure by using newer cross-rs base image with OpenSSL 3.x support.
+
+### Changed
+
+- Add PR-triggered build verification to release workflow for catching build failures before tagging.
+- Release workflow jobs (publish, container, GitHub release) now run only on tag push, not on PRs.
+
 ## v0.7.1
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "truss-image"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "truss-image"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 description = "Image toolkit with a shared Rust core across the CLI, HTTP server, and WASM demo."
 license = "MIT"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,4 +1,5 @@
 [target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main"
 pre-build = [
-    "dpkg --add-architecture arm64 && apt-get update && apt-get install -y libssl-dev:arm64",
+    "dpkg --add-architecture arm64 && apt-get update && apt-get install -y libssl-dev:arm64 pkg-config",
 ]

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Truss Image Server API
-  version: 0.7.1
+  version: 0.7.2
   description: |
     HTTP API for the Truss image toolkit.
 
@@ -346,7 +346,7 @@ paths:
               example:
                 status: ok
                 service: truss
-                version: 0.7.1
+                version: 0.7.2
                 uptimeSeconds: 3600
                 checks:
                   - name: storageRoot
@@ -385,7 +385,7 @@ paths:
               example:
                 status: ok
                 service: truss
-                version: 0.7.1
+                version: 0.7.2
 
   /health/ready:
     get:


### PR DESCRIPTION
## Summary
- Fix aarch64 cross-compilation failure by using newer cross-rs base image (`main`) with OpenSSL 3.x support
- Add `pull_request` trigger to release workflow for build verification before tagging
- Gate publish/container/GitHub Release jobs to tag-push only
- Bump version to v0.7.2 and update CHANGELOG/OpenAPI spec

## Test plan
- [ ] Release workflow build jobs succeed for all targets (x86_64-linux, aarch64-linux, x86_64-macos, aarch64-macos, x86_64-windows) on PR
- [ ] Publish/container/release jobs are skipped on PR (tag-push only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved aarch64 cross-compilation issues with OpenSSL 3.x library support

* **Chores**
  * Restructured release workflow for streamlined tag-based deployment and automated publishing
  * Updated version to 0.7.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->