### PR TITLE
feat: cache syscall results in health check endpoints

### DIFF
--- a/src/adapters/server/config.rs
+++ b/src/adapters/server/config.rs
@@ -430,7 +430,10 @@ pub struct ServerConfig {
     ///
     /// The TTL is configurable via `TRUSS_HEALTH_CACHE_TTL_SECS`. Defaults to 5
     /// seconds. Set to `0` to disable caching.
-    pub health_cache: Arc<super::handler::HealthCache>,
+    ///
+    /// Use [`ServerConfig::with_health_cache_ttl_secs`] to override the TTL
+    /// programmatically.
+    pub(crate) health_cache: Arc<super::handler::HealthCache>,
     /// Drain period (in seconds) during graceful shutdown.
     ///
     /// On receiving a shutdown signal the server immediately marks itself as
@@ -831,6 +834,15 @@ impl ServerConfig {
             #[cfg(feature = "azure")]
             azure_context: None,
         }
+    }
+
+    /// Overrides the health-check syscall cache TTL.
+    ///
+    /// This builder-style method allows embedders to configure the TTL
+    /// programmatically without relying on environment variables.
+    pub fn with_health_cache_ttl_secs(mut self, ttl_secs: u64) -> Self {
+        self.health_cache = Arc::new(super::handler::HealthCache::new(ttl_secs));
+        self
     }
 
     #[cfg(any(feature = "s3", feature = "gcs", feature = "azure"))]
@@ -2352,5 +2364,19 @@ mod tests {
         let _env = ScopedEnv::set("TRUSS_HEALTH_CACHE_TTL_SECS", "0");
         let result = parse_env_u64_ranged("TRUSS_HEALTH_CACHE_TTL_SECS", 0, 300);
         assert_eq!(result.unwrap(), Some(0));
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_wires_health_cache_ttl_secs() {
+        let _env = ScopedEnv::set("TRUSS_HEALTH_CACHE_TTL_SECS", "10");
+        let config = ServerConfig::from_env().unwrap();
+        assert_eq!(config.health_cache.ttl_nanos, 10 * 1_000_000_000);
+    }
+
+    #[test]
+    fn with_health_cache_ttl_secs_overrides_default() {
+        let config = ServerConfig::new(PathBuf::from("."), None).with_health_cache_ttl_secs(20);
+        assert_eq!(config.health_cache.ttl_nanos, 20 * 1_000_000_000);
     }
 }

--- a/src/adapters/server/handler.rs
+++ b/src/adapters/server/handler.rs
@@ -523,7 +523,7 @@ pub(super) const DEFAULT_HEALTH_CACHE_TTL_SECS: u64 = 5;
 /// Caches `disk_free_bytes()` and `process_rss_bytes()` with a configurable
 /// TTL so that high-frequency polling does not generate redundant kernel
 /// context switches and file I/O.
-pub struct HealthCache {
+pub(crate) struct HealthCache {
     disk_free: AtomicU64,
     disk_free_at: AtomicU64,
     rss: AtomicU64,
@@ -767,7 +767,7 @@ fn collect_resource_checks(config: &ServerConfig) -> (Vec<serde_json::Value>, bo
     (checks, all_ok)
 }
 
-/// Returns storage backend health checks (storage root writability and cloud
+/// Returns storage backend health checks (storage root existence and cloud
 /// backend reachability).
 pub(super) fn storage_health_check(config: &ServerConfig) -> Vec<(bool, &'static str)> {
     #[allow(unused_mut)]

--- a/src/adapters/server/mod.rs
+++ b/src/adapters/server/mod.rs
@@ -48,7 +48,7 @@ mod signing;
 #[cfg(any(feature = "s3", feature = "gcs", feature = "azure"))]
 pub use config::StorageBackend;
 pub use config::{DEFAULT_BIND_ADDR, DEFAULT_STORAGE_ROOT, LogHandler, LogLevel, ServerConfig};
-pub use handler::{HealthCache, TransformOptionsPayload};
+pub use handler::TransformOptionsPayload;
 pub use lifecycle::{serve, serve_once, serve_once_with_config, serve_with_config};
 pub use signing::{SignedUrlSource, SignedWatermarkParams, bind_addr, sign_public_url};
 


### PR DESCRIPTION
## Summary

- Add lock-free `HealthCache` that caches `disk_free_bytes()` and `process_rss_bytes()` results with a configurable TTL (default 5s), eliminating redundant kernel context switches under high-frequency health polling
- Add `TRUSS_HEALTH_CACHE_TTL_SECS` environment variable (0–300, default 5) to control cache duration; set to 0 to disable caching
- Extract `collect_resource_checks()` helper to deduplicate ~70 lines of identical check logic between `handle_health()` and `handle_health_ready()`
- Remove unused `TransformImageRequestPayload` import

Closes #74

## Test plan

- [x] Unit tests for `HealthCache`: cached values within TTL, refresh after TTL, TTL=0 bypass, default TTL in `ServerConfig`
- [x] Unit tests for `TRUSS_HEALTH_CACHE_TTL_SECS` env var parsing (valid value, zero)
- [x] All 913 existing tests pass
- [x] `cargo clippy --tests` reports zero warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Performance-optimized health check caching with configurable TTL (default 5s) via TRUSS_HEALTH_CACHE_TTL_SECS; setting TTL to 0 disables caching
  * Health endpoints now return unified, richer payloads including service, version, uptime, max input pixels, and per-check details
  * Health cache available as a public component for integrations

* **Tests**
  * Added tests covering TTL parsing, cache behavior, and default TTL handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->