### PR TITLE
Batch update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.126.0"
+version = "1.127.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7878050a2321d215eec9db8be09f8db59418b53860ae86cc7042b4094d6cb2bb"
+checksum = "151783f64e0dcddeb4965d08e36c276b4400a46caa88805a2e36d497deaf031a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -5039,9 +5039,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
  "flate2",
@@ -5050,15 +5050,15 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-pki-types",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-roots",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
  "http 1.4.0",
@@ -5113,10 +5113,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.145", optional = true }
 sha2 = { version = "0.10.9", optional = true }
 subtle = { version = "2", optional = true }
-ureq = { version = "3.2.0", optional = true }
+ureq = { version = "3.3.0", optional = true }
 url = { version = "2.5.8", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
 rav1d-safe = { version = "0.3", default-features = false, features = ["bitdepth_8", "bitdepth_16"], optional = true }

--- a/examples/vite-truss-wasm/package-lock.json
+++ b/examples/vite-truss-wasm/package-lock.json
@@ -9,12 +9,21 @@
         "@nao1215/truss-wasm": "file:../../packages/truss-wasm"
       },
       "devDependencies": {
-        "puppeteer-core": "^24.5.0",
+        "puppeteer-core": "^24.40.0",
         "vite": "^7.1.7",
         "vite-plugin-top-level-await": "^1.6.0"
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "../../packages/truss-wasm": {
+      "name": "@nao1215/truss-wasm",
+      "version": "0.11.4",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nao1215"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -460,13 +469,8 @@
       }
     },
     "node_modules/@nao1215/truss-wasm": {
-      "version": "0.11.4",
-      "resolved": "file:../../packages/truss-wasm",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nao1215"
-      }
+      "resolved": "../../packages/truss-wasm",
+      "link": true
     },
     "node_modules/@puppeteer/browsers": {
       "version": "2.13.0",
@@ -1814,6 +1818,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1903,6 +1908,7 @@
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
       "integrity": "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.13.0",
         "chromium-bidi": "14.0.0",

--- a/examples/vite-truss-wasm/package-lock.json
+++ b/examples/vite-truss-wasm/package-lock.json
@@ -17,15 +17,6 @@
         "node": ">=22"
       }
     },
-    "../../packages/truss-wasm": {
-      "name": "@nao1215/truss-wasm",
-      "version": "0.11.4",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nao1215"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
@@ -469,8 +460,13 @@
       }
     },
     "node_modules/@nao1215/truss-wasm": {
-      "resolved": "../../packages/truss-wasm",
-      "link": true
+      "version": "0.11.4",
+      "resolved": "file:../../packages/truss-wasm",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nao1215"
+      }
     },
     "node_modules/@puppeteer/browsers": {
       "version": "2.13.0",
@@ -1814,11 +1810,10 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1904,11 +1899,10 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.39.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.39.1.tgz",
-      "integrity": "sha512-AMqQIKoEhPS6CilDzw0Gd1brLri3emkC+1N2J6ZCCuY1Cglo56M63S0jOeBZDQlemOiRd686MYVMl9ELJBzN3A==",
+      "version": "24.40.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
+      "integrity": "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.13.0",
         "chromium-bidi": "14.0.0",

--- a/examples/vite-truss-wasm/package.json
+++ b/examples/vite-truss-wasm/package.json
@@ -14,7 +14,7 @@
     "@nao1215/truss-wasm": "file:../../packages/truss-wasm"
   },
   "devDependencies": {
-    "puppeteer-core": "^24.5.0",
+    "puppeteer-core": "^24.40.0",
     "vite": "^7.1.7",
     "vite-plugin-top-level-await": "^1.6.0"
   }


### PR DESCRIPTION
## Summary
- ureq: 3.2.0 → 3.3.0
- aws-sdk-s3: 1.126.0 → 1.127.0
- aws-smithy-types: 1.4.6 → 1.4.7
- picomatch: 4.0.3 → 4.0.4
- puppeteer-core: 24.39.1 → 24.40.0

## Skipped
- **azure_storage_blob 0.9 → 0.10.1**: Breaking changes (upload API, Etag types, etc.)
- **vite 7.3.1 → 8.0.1**: Major version bump; wasm-package CI fails on all platforms

Consolidates #172, #175, #176, #177, #178.

## Test plan
- [x] `cargo check --all-features` passes
- [x] `cargo test --all-features` passes (1089 unit + 36 doc tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an optional HTTP client dependency to a newer release to keep network-related tooling up to date.
  * Updated a developer tooling dependency used in example projects to a newer release to align with current local/dev environment tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->