### PR TITLE
chore(ci): pin integration test images to fixed versions

### DIFF
--- a/integration/api/compose.yml
+++ b/integration/api/compose.yml
@@ -15,7 +15,7 @@ services:
       - no-new-privileges:true
 
   runn:
-    image: ghcr.io/k1low/runn:latest
+    image: ghcr.io/k1low/runn:v1.9.2
     depends_on:
       - truss
     volumes:

--- a/integration/azure/compose.yml
+++ b/integration/azure/compose.yml
@@ -1,6 +1,6 @@
 services:
   azurite:
-    image: mcr.microsoft.com/azure-storage/azurite:latest
+    image: mcr.microsoft.com/azure-storage/azurite:3.35.0
     command: ["azurite-blob", "--blobHost", "0.0.0.0", "--blobPort", "10000", "--skipApiVersionCheck"]
     # Azurite exposes Blob service on port 10000
     healthcheck:
@@ -47,7 +47,7 @@ services:
     # nginx listens on port 80
 
   runn:
-    image: ghcr.io/k1low/runn:latest
+    image: ghcr.io/k1low/runn:v1.9.2
     depends_on:
       - nginx
       - truss

--- a/integration/gcs/compose.yml
+++ b/integration/gcs/compose.yml
@@ -1,6 +1,6 @@
 services:
   fake-gcs:
-    image: fsouza/fake-gcs-server:latest
+    image: fsouza/fake-gcs-server:1.54.0
     command: ["-scheme", "http", "-port", "4443"]
     # fake-gcs-server exposes HTTP on 4443
     healthcheck:
@@ -46,7 +46,7 @@ services:
     # nginx listens on port 80
 
   runn:
-    image: ghcr.io/k1low/runn:latest
+    image: ghcr.io/k1low/runn:v1.9.2
     depends_on:
       - nginx
       - truss

--- a/integration/s3/compose.yml
+++ b/integration/s3/compose.yml
@@ -1,6 +1,9 @@
 services:
   s3mock:
-    image: adobe/s3mock:latest
+    # Pinned: s3mock 5.0.0 changed GET /<bucket> to return an HTTP error instead
+    # of 200, which breaks the readiness probe in setup-fixtures.sh. Stay on 4.x
+    # until that probe is migrated to the 5.x behavior. Do not float to :latest.
+    image: adobe/s3mock:4.11.0
     environment:
       initialBuckets: truss-test
     # s3mock exposes HTTP on 9090 by default
@@ -51,7 +54,7 @@ services:
     # nginx listens on port 80
 
   runn:
-    image: ghcr.io/k1low/runn:latest
+    image: ghcr.io/k1low/runn:v1.9.2
     depends_on:
       - nginx
       - truss


### PR DESCRIPTION
## Problem

The `integration (s3)` job started failing on `main` (and on #212) with:

```
runn-1 | ERROR: s3mock did not become ready (last status: 0)
```

even though s3mock itself starts fine. Root cause: **`adobe/s3mock:latest` rolled over to the new major `5.0.0`**, which changed `GET /<bucket>` to return an HTTP error instead of `200`. The readiness probe in `integration/s3/setup-fixtures.sh` waits for a `200`, so it never settles and times out.

Reproduced locally:
- `adobe/s3mock:4.11.0` → probe returns `200` on attempt 1, full integration passes (4 scenarios, 0 failures).
- `adobe/s3mock:5.0.0` → probe gets `HTTPError` forever, readiness times out (matches CI exactly).

This is the same class of problem as unpinned `:latest` tags drifting under us.

## Change

Pin every floating integration image to the version currently known-good:

| Image | Was | Now |
|---|---|---|
| `adobe/s3mock` | `:latest` (→5.0.0) | `4.11.0` |
| `fsouza/fake-gcs-server` | `:latest` | `1.54.0` |
| `mcr.microsoft.com/azure-storage/azurite` | `:latest` | `3.35.0` |
| `ghcr.io/k1low/runn` | `:latest` | `v1.9.2` |

## Verification

Ran the full `s3`, `gcs`, and `azure` compose stacks locally against the built `truss:local` image — all three pass (4 scenarios, 0 failures, `runn` exits 0). Compose config validates for all four services.

## Follow-up (not in this PR)

Migrating to s3mock 5.x will require updating the s3 readiness probe (and possibly the runbooks) to the new `GET /<bucket>` semantics. Tracked separately.