### PR TITLE
Bump version to v0.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.11.5
+
+### Changed
+
+- Batch dependency updates (consolidated from Dependabot PRs):
+  - Rust: `hmac` 0.12 → 0.13 and `sha2` 0.10 → 0.11 (RustCrypto `digest` 0.11); `rav1d-safe` 0.3 → 0.5; `azure_storage_blob` 0.9 → 0.10 with `azure_core` 0.32 → 0.33; `tokio` 1.50 → 1.52, `uuid` 1.22 → 1.23, `aws-sdk-s3` 1.127 → 1.129, `google-cloud-storage` 1.9 → 1.10, `google-cloud-auth` 1.7 → 1.8, `libc` 0.2.183 → 0.2.186, `rand` 0.9.2 → 0.9.4.
+  - Examples: `typescript` 5.9 → 6.0 (Next.js), `puppeteer-core` 24 → 25. `vite` kept on the 7.x line (7.3.5); Vite 8 drops the wasm-bindgen `new URL(..., import.meta.url)` asset reference and breaks the WASM example, so the upgrade is deferred.
+  - GitHub Actions: `actions/configure-pages` 5 → 6, `actions/upload-pages-artifact` 4 → 5, `actions/deploy-pages` 4 → 5, `softprops/action-gh-release` 2 → 3.
+- Pin integration-test container images to fixed versions (`adobe/s3mock` 4.11.0, `fsouza/fake-gcs-server` 1.54.0, `azurite` 3.35.0, `runn` v1.9.2) to avoid breakage from floating `:latest` tags. s3mock 5.0.0 changed `GET /<bucket>` to return an HTTP error instead of 200, which broke the s3 readiness probe.
+
+### Fixed
+
+- Update `rustls-webpki` 0.103.10 → 0.103.13 to patch RUSTSEC-2026-0098/0099/0104 (name-constraint bypass and CRL-parsing panic) on the modern rustls 0.23 path.
+- Ignore RUSTSEC-2026-0098/0099/0104 for the transitive `rustls-webpki` 0.101.7 (legacy AWS SDK `rustls` 0.21 path; upstream has not migrated yet — same rationale as RUSTSEC-2026-0049).
+
 ## v0.11.4
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "truss-image"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "truss-image"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 rust-version = "1.92"
 authors = ["CHIKAMATSU Naohiro <n.chika156@gmail.com>"]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Truss Image Server API
-  version: 0.11.4
+  version: 0.11.5
   description: |
     HTTP API for the Truss image toolkit.
 
@@ -499,7 +499,7 @@ paths:
               example:
                 status: ok
                 service: truss
-                version: 0.11.4
+                version: 0.11.5
                 uptimeSeconds: 3600
                 checks:
                   - name: storageRoot
@@ -562,7 +562,7 @@ paths:
               example:
                 status: ok
                 service: truss
-                version: 0.11.4
+                version: 0.11.5
         '429':
           $ref: '#/components/responses/TooManyRequests'
     head:
@@ -1424,7 +1424,7 @@ components:
         version:
           type: string
           description: Semantic version of the running binary.
-          example: "0.11.4"
+          example: "0.11.5"
     ReadinessResponse:
       type: object
       description: Readiness payload with individual dependency checks.
@@ -1453,7 +1453,7 @@ components:
         version:
           type: string
           description: Semantic version of the running binary.
-          example: "0.11.4"
+          example: "0.11.5"
         uptimeSeconds:
           type: integer
           format: int64

--- a/packages/truss-url-signer/package.json
+++ b/packages/truss-url-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nao1215/truss-url-signer",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Official Node.js/TypeScript signer for truss public image URLs.",
   "type": "module",
   "main": "./index.js",

--- a/packages/truss-wasm/package.json
+++ b/packages/truss-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nao1215/truss-wasm",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Official bundler-ready Wasm package for truss image transforms.",
   "type": "module",
   "main": "./dist/truss.js",


### PR DESCRIPTION
## Summary

Release v0.11.5 — bundles the batch dependency update (#212) and the integration-image pinning fix (#213) that have already landed on `main`.

Version bumped to `0.11.5` in `Cargo.toml`, `Cargo.lock`, `docs/openapi.yaml`, and both npm packages (`truss-wasm`, `truss-url-signer`), with a matching `CHANGELOG.md` entry.

After this merges, tagging `v0.11.5` triggers the release workflow (container, binaries, and npm package publishing).

## Highlights

- Rust deps: hmac 0.13 / sha2 0.11, rav1d-safe 0.5, azure_storage_blob 0.10 + azure_core 0.33, tokio 1.52, uuid 1.23, aws-sdk-s3 1.129, google-cloud-storage 1.10, google-cloud-auth 1.8, libc 0.2.186, rand 0.9.4.
- Security: rustls-webpki patched to 0.103.13; legacy rustls 0.21 advisories ignored with rationale.
- CI: integration images pinned (s3mock 4.11.0 etc.) to stop `:latest` drift breakage.
- Examples/Actions: typescript 6, puppeteer-core 25, Actions bumps. Vite kept on 7.x (Vite 8 breaks the WASM example).