### PR TITLE
build(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3489,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
Fixes the `security-audit` failure on `main`.

`quinn-proto` 0.11.14 is affected by **RUSTSEC-2026-0185** (remote memory exhaustion from unbounded out-of-order stream reassembly). It is a transitive dependency; `cargo update -p quinn-proto` bumps it to the patched 0.11.15 with no other changes.

This unblocks the security-audit check that was failing across all open dependency PRs.

https://claude.ai/code/session_01KZSMEqbR6XncVQQ67CzmBW