### PR TITLE
build(deps): bump azure_core to 0.34 and azure_storage_blob to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0160068f7a3021b5e749dc552374e82360463e9fb51e1127631a69fdde641f"
+checksum = "688882dc4a96b0ea158299d590fad91c471eced6403fd9a9ea1992c14397f25f"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -778,6 +800,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
  "typespec",
  "typespec_client_core",
@@ -785,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "azure_core_macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd69a8e70ec6be32ebf7e947cf9a58f6c7255e4cd9c48e640532ef3e37adc6d"
+checksum = "70066e34b8db2c3f0b852c56a99333bd25fdedfb8850cd95dddf930928b47b80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -797,10 +820,11 @@ dependencies = [
 
 [[package]]
 name = "azure_storage_blob"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72693fc24f79adee4b3df7469b29724aa7ea25b908ea0e23f62b93f01f098283"
+checksum = "b3078fd7c5871c8b785302872e41731421d64e3d594753c1d373e2f4aac0db3e"
 dependencies = [
+ "async-stream",
  "async-trait",
  "azure_core",
  "bytes",
@@ -810,6 +834,7 @@ dependencies = [
  "serde",
  "serde_json",
  "time",
+ "tokio",
 ]
 
 [[package]]
@@ -5058,9 +5083,9 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typespec"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63559a2aab9c7694fa8d2658a828d6b36f1e3904b1860d820c7cc6a2ead61c7"
+checksum = "247afbeabe0c383f630d0fdcb4fb92818c31cd3fe5d293335daff8cac79d4e0f"
 dependencies = [
  "base64",
  "bytes",
@@ -5073,12 +5098,13 @@ dependencies = [
 
 [[package]]
 name = "typespec_client_core"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de81ecf3a175da5a10ed60344caa8b53fe6d8ce28c6c978a7e3e09ca1e1b4131"
+checksum = "66166c78ee5b5a03b665a639899414a468f645f58dba3c8154b82d64847d227b"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "dyn-clone",
  "futures",
  "pin-project",
@@ -5087,6 +5113,7 @@ dependencies = [
  "serde",
  "serde_json",
  "time",
+ "tokio",
  "tracing",
  "typespec",
  "typespec_macros",
@@ -5096,9 +5123,9 @@ dependencies = [
 
 [[package]]
 name = "typespec_macros"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07108c5d18e00ec7bb09d2e48df95ebfab6b7179112d1e4216e9968ac2a0a429"
+checksum = "d17153fde258b3c862cecffad95e185c0eb83e619e76542c4b3ed9828af840f0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ aws-config = { version = "1", optional = true }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "time"], optional = true }
 google-cloud-storage = { version = "1", optional = true }
 google-cloud-auth = { version = "1", optional = true }
-azure_storage_blob = { version = "0.10", optional = true }
-azure_core = { version = "0.33", optional = true }
+azure_storage_blob = { version = "0.11", optional = true }
+azure_core = { version = "0.34", optional = true }
 futures = { version = "0.3", optional = true }
 flate2 = { version = "1", optional = true }
 libc = { version = "0.2", optional = true }

--- a/src/adapters/server/azure.rs
+++ b/src/adapters/server/azure.rs
@@ -188,8 +188,7 @@ pub(super) fn read_azure_source_bytes(
 
             let resp = client.download(None).await.map_err(map_azure_error)?;
 
-            use azure_storage_blob::models::BlobClientDownloadResultHeaders;
-            let content_length = resp.content_length().ok().flatten();
+            let content_length = resp.properties.content_length;
             if let Some(len) = content_length
                 && len > MAX_SOURCE_BYTES
             {
@@ -198,7 +197,7 @@ pub(super) fn read_azure_source_bytes(
                 ));
             }
 
-            let (_, _, body) = resp.deconstruct();
+            let body = resp.body;
 
             use futures::StreamExt;
             let capacity = if let Some(len) = content_length {


### PR DESCRIPTION
Combines the two Dependabot bumps #231 (azure_core 0.33→0.34) and #230 (azure_storage_blob 0.10→0.11) because they must move together to keep a single `typespec` version (0.14) in the lockfile — bumping only one leaves two `typespec` versions and an `ErrorKind` type mismatch.

### API change handled
`azure_storage_blob` 0.11 reworked the download result. `download()` now returns `BlobClientDownloadResult` directly with public fields:
- `body: AsyncResponseBody` (the stream)
- `properties: BlobDownloadProperties` (incl. `content_length`)
- `headers: Headers`

This replaces the old `Response`-style wrapper that exposed `content_length()` and `deconstruct()`. The download path in `azure.rs` was updated to read `resp.properties.content_length` and `resp.body`.

Build, clippy, and the azure unit tests pass locally.

Supersedes #231 and #230.

https://claude.ai/code/session_01KZSMEqbR6XncVQQ67CzmBW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Azure-related support packages to newer versions for improved compatibility.
  * Adjusted Azure blob handling to work with the latest service response format, helping keep Azure file reads reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->