### PR TITLE
fix(deps): upgrade quick-xml to 0.41 for RUSTSEC-2026-0194/0195

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,9 +7,17 @@
 # bypass) or the app to parse attacker-controlled CRLs (CRL panic), which truss does
 # not do through this path. Practical risk is therefore low.
 # The modern rustls 0.23 path uses the patched rustls-webpki 0.103.13.
+#
+# RUSTSEC-2026-0194 / RUSTSEC-2026-0195 (quick-xml < 0.41: attribute-check DoS and
+# NsReader namespace-allocation DoS): truss's own quick-xml (SVG parsing) is on the
+# patched 0.41, but the Azure SDK path (azure_core -> typespec 0.14) still pins
+# quick-xml ^0.39 and only uses it to parse Azure's own XML API responses — not
+# attacker-supplied documents. Remove these once typespec bumps quick-xml >= 0.41.
 ignore = [
     "RUSTSEC-2026-0049",
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
     "RUSTSEC-2026-0104",
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2442,7 +2442,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3489,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3509,7 +3509,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.41",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3547,7 +3547,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5044,7 +5044,7 @@ dependencies = [
  "kamadak-exif",
  "libc",
  "mp4parse",
- "quick-xml 0.40.1",
+ "quick-xml 0.41.0",
  "rav1d-safe",
  "resvg",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ mp4parse = { version = "0.17", optional = true }
 yuvutils-rs = { version = "0.8", optional = true }
 wasm-bindgen = { version = "0.2.114", optional = true }
 webp = { version = "0.3", optional = true }
-quick-xml = { version = "0.40", optional = true }
+quick-xml = { version = "0.41", optional = true }
 resvg = { version = "0.47", optional = true }
 aws-sdk-s3 = { version = "1", optional = true }
 aws-config = { version = "1", optional = true }


### PR DESCRIPTION
## Summary

The `security-audit` job started failing on 2026-07-03 after [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) and [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) (published 2026-06-29) flagged `quick-xml < 0.41`: quadratic attribute duplicate-checking and unbounded `NsReader` namespace allocation, both remote DoS vectors on untrusted XML. This is unrelated to any code change — the last green main run predates the advisory database update.

Two lockfile instances were flagged:

1. **`quick-xml` 0.40.1 (direct, SVG parsing)** — truss parses untrusted SVG here, so this is the instance that matters. Bumped `Cargo.toml` to `0.41` and updated the lockfile. Build and the 1,000-test unit suite pass unchanged.
2. **`quick-xml` 0.39.4 (transitive via `azure_core` → `typespec` 0.14)** — `typespec` pins `^0.39`, so it cannot move until the Azure SDK bumps it. That path only parses Azure's own XML API responses, not attacker-supplied documents, so the practical risk is low. Added both advisory IDs to the existing `.cargo/audit.toml` ignore list with a comment saying exactly when to remove them (typespec quick-xml >= 0.41).

## Verification

- `cargo build --release --locked` — green
- `cargo test --lib` — 1000 passed, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled XML parsing dependency to a newer optional version.
  * Adjusted security audit exclusions for known advisories tied to a transitive dependency path, with notes for future cleanup once upstream updates land.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->