### PR TITLE
docs(readme): update repository badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![API Integration](https://github.com/nao1215/truss/actions/workflows/integration.yml/badge.svg)](https://github.com/nao1215/truss/actions/workflows/integration.yml)
 [![Crates.io](https://img.shields.io/crates/v/truss-image)](https://crates.io/crates/truss-image)
 [![Crates.io Downloads](https://img.shields.io/crates/d/truss-image)](https://crates.io/crates/truss-image)
+[![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/nao1215/truss/total)](https://github.com/nao1215/truss/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-stable-orange)](https://www.rust-lang.org/)
 


### PR DESCRIPTION
## Summary
Refresh the README badge section to show total GitHub downloads and remove the deprecated Go Report Card badge where it still appears.

## Changes
- add the GitHub downloads badge to the main README badge row
- remove the Go Report Card badge from repositories that still reference it
- keep existing badge ordering while normalizing the downloads badge link to the releases page

## Design Decisions
- use the same Shields.io GitHub downloads badge format across repositories
- keep the change documentation-only with no behavioral impact
