### PR TITLE
chore(ci): bump atago to v0.17.0

### DIFF
--- a/.github/workflows/integration-cli.yml
+++ b/.github/workflows/integration-cli.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.16.0
+          version: v0.17.0
 
       # e2e/run.sh builds truss (cargo build --release --locked) and runs the
       # atago specs in e2e/atago against the freshly built binary.


### PR DESCRIPTION
Pins the E2E suites to [atago v0.17.0](https://github.com/nao1215/atago/releases/tag/v0.17.0).

That release adds a Scoop bucket for Windows installs and carries two failure-message fixes: an assertion whose observed value was empty now renders `(empty)` instead of omitting the `Actual:` section, and a run step whose output capture was cut short now names the exit code the process reached instead of reporting `failed to execute`.

No spec changes are needed — neither fix alters an assertion's verdict, only how a failure reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CLI integration workflow to use atago version v0.17.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->