### PR TITLE
fix(convert): enforce output pixel limit against aspect-scaled size

### DIFF
--- a/.atago/last-failed.json
+++ b/.atago/last-failed.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "1",
+  "failed": [
+    {
+      "spec_path": "e2e/atago/limits.atago.yaml",
+      "scenario": "applies the same limit to the optimize subcommand"
+    }
+  ]
+}

--- a/.atago/last-failed.json
+++ b/.atago/last-failed.json
@@ -1,9 +1,0 @@
-{
-  "schema_version": "1",
-  "failed": [
-    {
-      "spec_path": "e2e/atago/limits.atago.yaml",
-      "scenario": "applies the same limit to the optimize subcommand"
-    }
-  ]
-}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ target
 #.idea/
 work
 web/dist/
+
+# atago run state (local last-failed cache)
+.atago/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- `convert`/`optimize`: enforce `MAX_OUTPUT_PIXELS` against the real output size when only one of `--width`/`--height` is given ([#252](https://github.com/nao1215/truss/issues/252)). The check previously used the *source* size for the omitted axis, so `--width 10000` on a small image produced a 100-megapixel output with exit 0, and a large enough single dimension stalled while allocating the resize buffer.
 - `convert`/`optimize`: stop adding an alpha channel to opaque images ([#253](https://github.com/nao1215/truss/issues/253)). Every decoded image was widened to RGBA8 before encoding, so a no-op same-format pass flipped `hasAlpha` from `false` to `true` and grew the file. PNG, WebP, BMP, TIFF, and AVIF output now use an RGB color model whenever the pixels are fully opaque, and keep alpha whenever any pixel is not.
 - `inspect`: report `hasAlpha` for lossless WebP (VP8L) instead of `null`; the `alpha_is_used` header bit is now read.
 

--- a/e2e/atago/limits.atago.yaml
+++ b/e2e/atago/limits.atago.yaml
@@ -1,0 +1,117 @@
+# Output pixel-budget enforcement (MAX_OUTPUT_PIXELS = 67_108_864).
+#
+# Regression coverage for https://github.com/nao1215/truss/issues/252: the limit
+# used to be computed against the SOURCE size of whichever axis the user omitted,
+# so `--width 10000` on a 16x16 input passed the check and then allocated a
+# 100-megapixel buffer. The limit now runs against the aspect-scaled output size,
+# so a single oversized dimension is rejected before anything is allocated.
+#
+# The input is the committed 16x16 testdata/sample.png (square, so a width-only
+# resize scales the height by the same factor). Run with: e2e/run.sh
+version: "1"
+
+suite:
+  name: truss output pixel limits
+
+scenarios:
+  - name: rejects a width-only resize whose aspect-scaled output exceeds the limit
+    steps:
+      - fixture:
+          file: in.png
+          from: testdata/sample.png
+      - run:
+          command: truss convert in.png -o big.png --width 10000
+      - assert:
+          exit_code: 4
+          stderr:
+            contains:
+              - "error:"
+              - "output image would have 100000000 pixels"
+          # The output must never be written: the limit is a pre-allocation check.
+          changes:
+            created: []
+            modified: []
+            deleted: []
+      - assert:
+          file:
+            path: big.png
+            exists: false
+
+  - name: rejects a height-only resize whose aspect-scaled output exceeds the limit
+    steps:
+      - fixture:
+          file: in.png
+          from: testdata/sample.png
+      - run:
+          command: truss convert in.png -o tall.png --height 10000
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "output image would have 100000000 pixels"
+      - assert:
+          file:
+            path: tall.png
+            exists: false
+
+  - name: rejects a gigapixel width-only resize quickly instead of hanging
+    steps:
+      - fixture:
+          file: in.png
+          from: testdata/sample.png
+      # 65536x65536 is ~4.3 gigapixels. Before the fix this got past the check
+      # and stalled trying to allocate the resize buffer.
+      - run:
+          command: truss convert in.png -o huge.png --width 65536
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "output image would have"
+          duration:
+            lt: 20s
+      - assert:
+          file:
+            path: huge.png
+            exists: false
+
+  - name: rejects a resize when both dimensions exceed the limit together
+    steps:
+      - fixture:
+          file: in.png
+          from: testdata/sample.png
+      # 8193 * 8192 = 67_116_032, just over MAX_OUTPUT_PIXELS.
+      - run:
+          command: truss convert in.png -o both.png --width 8193 --height 8192
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "output image would have 67117056 pixels"
+
+  - name: allows a width-only resize that stays inside the limit
+    steps:
+      - fixture:
+          file: in.png
+          from: testdata/sample.png
+      - run:
+          command: truss convert in.png -o ok.png --width 512
+      - assert:
+          exit_code: 0
+          image:
+            path: ok.png
+            format: png
+            width: 512
+            height: 512
+
+  - name: allows a height-only resize that stays inside the limit
+    steps:
+      - fixture:
+          file: in.png
+          from: testdata/sample.png
+      - run:
+          command: truss convert in.png -o ok-h.png --height 512
+      - assert:
+          exit_code: 0
+          image:
+            path: ok-h.png
+            format: png
+            width: 512
+            height: 512

--- a/src/codecs/raster.rs
+++ b/src/codecs/raster.rs
@@ -645,19 +645,42 @@ fn check_input_pixel_limit(input: &Artifact) -> Result<(), TransformError> {
     Ok(())
 }
 
+/// Resolves the dimensions `apply_resize` will produce for the given request.
+///
+/// When only one axis is requested the other is derived from the source aspect ratio, exactly
+/// as `apply_resize` does, so callers see the real output size rather than the source size.
+fn resolved_output_dimensions(
+    current: (u32, u32),
+    width: Option<u32>,
+    height: Option<u32>,
+) -> (u32, u32) {
+    let (current_w, current_h) = current;
+    match (width, height) {
+        (None, None) => current,
+        (Some(target_width), None) => (
+            target_width,
+            scale_dimension(current_h, target_width, current_w),
+        ),
+        (None, Some(target_height)) => (
+            scale_dimension(current_w, target_height, current_h),
+            target_height,
+        ),
+        (Some(target_width), Some(target_height)) => (target_width, target_height),
+    }
+}
+
 /// Checks the output dimensions against [`MAX_OUTPUT_PIXELS`] before resize allocation.
 ///
 /// Computes the effective output pixel count from the requested dimensions and the current
-/// image size. The check runs before `apply_resize` so that oversized output buffers are
-/// never allocated.
+/// image size, deriving the omitted axis from the aspect ratio the same way `apply_resize`
+/// does. The check runs before `apply_resize` so that oversized output buffers are never
+/// allocated.
 fn check_output_pixel_limit(
     image: &DynamicImage,
     width: Option<u32>,
     height: Option<u32>,
 ) -> Result<(), TransformError> {
-    let (current_w, current_h) = image.dimensions();
-    let out_w = width.unwrap_or(current_w);
-    let out_h = height.unwrap_or(current_h);
+    let (out_w, out_h) = resolved_output_dimensions(image.dimensions(), width, height);
     let pixels = u64::from(out_w) * u64::from(out_h);
     if pixels > MAX_OUTPUT_PIXELS {
         return Err(TransformError::LimitExceeded(format!(
@@ -740,12 +763,11 @@ fn apply_resize(
 
     match (width, height) {
         (None, None) => image,
-        (Some(target_width), None) => {
-            let target_height = scale_dimension(original_height, target_width, original_width);
-            image.resize_exact(target_width, target_height, FilterType::Lanczos3)
-        }
-        (None, Some(target_height)) => {
-            let target_width = scale_dimension(original_width, target_height, original_height);
+        // Single-axis resize derives the other axis from the aspect ratio. The same helper
+        // backs `check_output_pixel_limit`, so the limit is applied to the real output size.
+        (Some(_), None) | (None, Some(_)) => {
+            let (target_width, target_height) =
+                resolved_output_dimensions((original_width, original_height), width, height);
             image.resize_exact(target_width, target_height, FilterType::Lanczos3)
         }
         (Some(target_width), Some(target_height)) => match fit.unwrap_or(Fit::Contain) {
@@ -3223,7 +3245,7 @@ mod tests {
     #[test]
     fn output_pixel_limit_rejects_oversized() {
         use super::check_output_pixel_limit;
-        // 8193 * 8192 = 67_116_032 > MAX_OUTPUT_PIXELS (67_108_864)
+        // 8193 * 8192 = 67_117_056 > MAX_OUTPUT_PIXELS (67_108_864)
         let image =
             image::DynamicImage::ImageRgba8(RgbaImage::from_pixel(1, 1, Rgba([0, 0, 0, 255])));
         let err = check_output_pixel_limit(&image, Some(8193), Some(8192)).unwrap_err();
@@ -3404,6 +3426,72 @@ mod tests {
         let round_tripped =
             sniff_artifact(RawArtifact::new(result.artifact.bytes, None)).expect("sniff output");
         assert_eq!(round_tripped.metadata.has_alpha, Some(false));
+    }
+
+    // Regression test for https://github.com/nao1215/truss/issues/252: the limit was
+    // computed against the *source* height when only --width was given, so a single
+    // oversized dimension slipped through and allocated a gigapixel buffer.
+    #[test]
+    fn output_pixel_limit_uses_aspect_scaled_height_when_only_width_is_given() {
+        use super::check_output_pixel_limit;
+
+        let image =
+            image::DynamicImage::ImageRgba8(RgbaImage::from_pixel(16, 16, Rgba([0, 0, 0, 255])));
+        // A square source scaled to width 10000 also becomes 10000 tall: 100 Mpx > 67_108_864.
+        let err = check_output_pixel_limit(&image, Some(10000), None).unwrap_err();
+        assert!(matches!(err, TransformError::LimitExceeded(_)));
+        assert!(err.to_string().contains("100000000"));
+    }
+
+    #[test]
+    fn output_pixel_limit_uses_aspect_scaled_width_when_only_height_is_given() {
+        use super::check_output_pixel_limit;
+
+        let image =
+            image::DynamicImage::ImageRgba8(RgbaImage::from_pixel(16, 16, Rgba([0, 0, 0, 255])));
+        let err = check_output_pixel_limit(&image, None, Some(10000)).unwrap_err();
+        assert!(matches!(err, TransformError::LimitExceeded(_)));
+        assert!(err.to_string().contains("100000000"));
+    }
+
+    #[test]
+    fn output_pixel_limit_accepts_aspect_scaled_single_dimension_within_limit() {
+        use super::check_output_pixel_limit;
+
+        // A 4:1 source scaled to width 8192 becomes 8192x2048 = 16_777_216 pixels.
+        let image =
+            image::DynamicImage::ImageRgba8(RgbaImage::from_pixel(16, 4, Rgba([0, 0, 0, 255])));
+        check_output_pixel_limit(&image, Some(8192), None).unwrap();
+    }
+
+    #[test]
+    fn transform_rejects_oversized_output_from_width_only_resize() {
+        let input = png_artifact(16, 16, Rgba([10, 20, 30, 255]));
+        let err = transform_raster(TransformRequest::new(
+            input,
+            TransformOptions {
+                width: Some(10000),
+                ..TransformOptions::default()
+            },
+        ))
+        .unwrap_err();
+        assert!(matches!(err, TransformError::LimitExceeded(_)));
+        assert!(err.to_string().contains("output image"));
+    }
+
+    #[test]
+    fn transform_rejects_oversized_output_from_height_only_resize() {
+        let input = png_artifact(16, 16, Rgba([10, 20, 30, 255]));
+        let err = transform_raster(TransformRequest::new(
+            input,
+            TransformOptions {
+                height: Some(10000),
+                ..TransformOptions::default()
+            },
+        ))
+        .unwrap_err();
+        assert!(matches!(err, TransformError::LimitExceeded(_)));
+        assert!(err.to_string().contains("output image"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #252.

`check_output_pixel_limit` substituted the **source** size for whichever axis the user omitted, so `MAX_OUTPUT_PIXELS` (67,108,864) was never applied to the axis that resize derives from the aspect ratio. On a 16x16 input:

- `--width 10000` produced a 10000x10000 (100 Mpx) output with exit 0.
- `--width 65536` got past the check and stalled allocating a ~4.3 gigapixel buffer.

## Changes

- Add `resolved_output_dimensions()`, which reproduces the aspect-ratio scaling `apply_resize` performs, and use it from both `check_output_pixel_limit` and `apply_resize` so the checked size and the produced size cannot drift apart.
- The limit now rejects single-dimension resizes before any buffer is allocated (exit 4, no output file written).

## Tests

- Unit: aspect-scaled rejection for width-only and height-only requests, an in-limit single-dimension case, and end-to-end `transform_raster` rejection for both directions.
- E2E (atago, `e2e/atago/limits.atago.yaml`): reproduces the issue's exact commands against the real binary — exit code 4, the `output image would have 100000000 pixels` message, `changes: created: []` proving no file is written, and a `duration: lt: 20s` bound on the `--width 65536` case that used to hang.

Also corrects a stale comment: 8193 * 8192 is 67,117,056, not 67,116,032.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced output pixel limits using the actual resized dimensions when only width or height is specified.
  * Prevented oversized image allocations and stalled operations during large resizes.
  * Improved error reporting for pixel-limit violations.

* **Tests**
  * Added coverage for oversized, gigapixel, combined-dimension, and valid single-axis resize scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->