### PR TITLE
fix(convert): keep opaque images free of an alpha channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `convert`/`optimize`: stop adding an alpha channel to opaque images ([#253](https://github.com/nao1215/truss/issues/253)). Every decoded image was widened to RGBA8 before encoding, so a no-op same-format pass flipped `hasAlpha` from `false` to `true` and grew the file. PNG, WebP, BMP, TIFF, and AVIF output now use an RGB color model whenever the pixels are fully opaque, and keep alpha whenever any pixel is not.
+- `inspect`: report `hasAlpha` for lossless WebP (VP8L) instead of `null`; the `alpha_is_used` header bit is now read.
+
 ## v0.11.5
 
 ### Changed

--- a/e2e/atago/color_model.atago.yaml
+++ b/e2e/atago/color_model.atago.yaml
@@ -1,0 +1,187 @@
+# Color-model preservation across a transform.
+#
+# Regression coverage for https://github.com/nao1215/truss/issues/253: every decoded
+# image was widened to RGBA8 before encoding, so a no-op `truss convert in.png -o out.png`
+# on an opaque PNG flipped `hasAlpha` from false to true and grew the file. An alpha
+# channel is now written only when the pixels actually need one.
+#
+# `truss inspect` reads the color model straight out of the encoded header, which is the
+# observable the issue reports on; atago's `image: alpha:` assertion scans decoded pixels,
+# so the two together pin both the container and the pixels. Run with: e2e/run.sh
+version: "1"
+
+suite:
+  name: truss color model preservation
+
+scenarios:
+  - name: a no-op same-format pass keeps an opaque PNG opaque
+    steps:
+      - fixture:
+          file: in.png
+          from: testdata/sample.png
+      - run:
+          command: truss inspect in.png
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: $.hasAlpha
+              equals: false
+      - run:
+          command: truss convert in.png -o out.png
+      - assert:
+          exit_code: 0
+      - run:
+          command: truss inspect out.png
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: $.hasAlpha
+              equals: false
+      - assert:
+          image:
+            path: out.png
+            format: png
+            alpha: false
+      # A same-format pass must not change the pixels either.
+      - assert:
+          image:
+            path: out.png
+            similar_to: testdata/sample.png
+
+  - name: a resize keeps an opaque PNG opaque
+    steps:
+      - fixture:
+          file: in.png
+          from: testdata/sample.png
+      - run:
+          command: truss convert in.png -o resized.png --width 32
+      - assert:
+          exit_code: 0
+      - run:
+          command: truss inspect resized.png
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: $.hasAlpha
+              equals: false
+
+  - name: an opaque PNG stays opaque through WebP output
+    steps:
+      - fixture:
+          file: in.png
+          from: testdata/sample.png
+      - run:
+          command: truss convert in.png -o out.webp --format webp
+      - assert:
+          exit_code: 0
+      - run:
+          command: truss inspect out.webp
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: $.hasAlpha
+              equals: false
+
+  - name: an opaque PNG stays opaque through BMP output
+    steps:
+      - fixture:
+          file: in.png
+          from: testdata/sample.png
+      - run:
+          command: truss convert in.png -o out.bmp --format bmp
+      - assert:
+          exit_code: 0
+      - run:
+          command: truss inspect out.bmp
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: $.hasAlpha
+              equals: false
+
+  - name: transparency survives a same-format PNG pass
+    steps:
+      - run:
+          shell: true
+          command: truss convert "$FIXTURES_DIR/transparent.png" -o keep.png
+      - assert:
+          exit_code: 0
+          image:
+            path: keep.png
+            format: png
+            alpha: true
+      - run:
+          command: truss inspect keep.png
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: $.hasAlpha
+              equals: true
+
+  - name: transparency survives conversion to WebP
+    steps:
+      - run:
+          shell: true
+          command: truss convert "$FIXTURES_DIR/transparent.png" -o keep.webp --format webp
+      - assert:
+          exit_code: 0
+      - run:
+          command: truss inspect keep.webp
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: $.hasAlpha
+              equals: true
+
+  - name: padding an opaque image into a wider box adds the alpha it needs
+    steps:
+      - fixture:
+          file: in.png
+          from: testdata/sample.png
+      # fit=contain letterboxes with the default transparent background, so the output
+      # genuinely needs an alpha channel.
+      - run:
+          command: truss convert in.png -o padded.png --width 32 --height 16 --fit contain
+      - assert:
+          exit_code: 0
+          image:
+            path: padded.png
+            format: png
+            alpha: true
+      - run:
+          command: truss inspect padded.png
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: $.hasAlpha
+              equals: true
+
+  - name: padding with an opaque background keeps the output opaque
+    steps:
+      - fixture:
+          file: in.png
+          from: testdata/sample.png
+      - run:
+          command: truss convert in.png -o padded-white.png --width 32 --height 16 --fit contain --background ffffff
+      - assert:
+          exit_code: 0
+          image:
+            path: padded-white.png
+            format: png
+            alpha: false
+      - run:
+          command: truss inspect padded-white.png
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: $.hasAlpha
+              equals: false

--- a/src/codecs/raster.rs
+++ b/src/codecs/raster.rs
@@ -1674,6 +1674,65 @@ fn encode_jpeg(
     Ok(bytes)
 }
 
+/// Returns `true` when any pixel of `image` is non-opaque.
+///
+/// A color model that carries an alpha channel does not imply the image uses it: decoders and
+/// the padding helpers routinely widen opaque images to RGBA. Scanning the samples is what lets
+/// the encoders drop an alpha channel that holds no information.
+fn image_has_transparency(image: &DynamicImage) -> bool {
+    match image {
+        DynamicImage::ImageLumaA8(buffer) => buffer.pixels().any(|pixel| pixel[1] != u8::MAX),
+        DynamicImage::ImageLumaA16(buffer) => buffer.pixels().any(|pixel| pixel[1] != u16::MAX),
+        DynamicImage::ImageRgba8(buffer) => buffer.pixels().any(|pixel| pixel[3] != u8::MAX),
+        DynamicImage::ImageRgba16(buffer) => buffer.pixels().any(|pixel| pixel[3] != u16::MAX),
+        DynamicImage::ImageRgba32F(buffer) => buffer.pixels().any(|pixel| pixel[3] < 1.0),
+        // Every other variant is alpha-less by construction.
+        _ => false,
+    }
+}
+
+/// The 8-bit sample buffer an encoder writes, narrowed to RGB when the image is fully opaque.
+///
+/// Encoding an opaque image as RGBA adds an alpha channel the input never had, which inflates
+/// the output and breaks the expectation that a same-format pass preserves the color model
+/// (<https://github.com/nao1215/truss/issues/253>). Dropping an all-opaque alpha channel is
+/// pixel-lossless, so the narrower form is always safe.
+enum EncodeSamples {
+    Rgb(image::RgbImage),
+    Rgba(RgbaImage),
+}
+
+impl EncodeSamples {
+    fn from_image(image: &DynamicImage) -> Self {
+        if image_has_transparency(image) {
+            Self::Rgba(image.to_rgba8())
+        } else {
+            Self::Rgb(image.to_rgb8())
+        }
+    }
+
+    fn color_type(&self) -> ColorType {
+        match self {
+            Self::Rgb(_) => ColorType::Rgb8,
+            Self::Rgba(_) => ColorType::Rgba8,
+        }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::Rgb(buffer) => buffer.as_raw(),
+            Self::Rgba(buffer) => buffer.as_raw(),
+        }
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self {
+            Self::Rgb(buffer) => buffer.dimensions(),
+            Self::Rgba(buffer) => buffer.dimensions(),
+        }
+    }
+}
+
 fn encode_png(
     image: &DynamicImage,
     retained_metadata: Option<&RetainedMetadata>,
@@ -1694,9 +1753,15 @@ fn encode_png(
                 .map_err(|error| TransformError::EncodeFailed(error.to_string()))?;
         }
     }
-    let rgba = image.to_rgba8();
+    let samples = EncodeSamples::from_image(image);
+    let (width, height) = samples.dimensions();
     encoder
-        .write_image(&rgba, rgba.width(), rgba.height(), ColorType::Rgba8.into())
+        .write_image(
+            samples.as_bytes(),
+            width,
+            height,
+            samples.color_type().into(),
+        )
         .map_err(|error| TransformError::EncodeFailed(error.to_string()))?;
     Ok(bytes)
 }
@@ -1706,7 +1771,7 @@ fn encode_webp_lossless(
     retained_metadata: Option<&RetainedMetadata>,
 ) -> Result<EncodedOutput, TransformError> {
     let mut bytes = Vec::new();
-    let rgba = image.to_rgba8();
+    let samples = EncodeSamples::from_image(image);
     let mut encoder = WebPEncoder::new_lossless(&mut bytes);
     if let Some(retained_metadata) = retained_metadata {
         if let Some(icc_profile) = &retained_metadata.icc_profile {
@@ -1720,8 +1785,14 @@ fn encode_webp_lossless(
                 .map_err(|error| TransformError::EncodeFailed(error.to_string()))?;
         }
     }
+    let (width, height) = samples.dimensions();
     encoder
-        .write_image(&rgba, rgba.width(), rgba.height(), ColorType::Rgba8.into())
+        .write_image(
+            samples.as_bytes(),
+            width,
+            height,
+            samples.color_type().into(),
+        )
         .map_err(|error| TransformError::EncodeFailed(error.to_string()))?;
 
     Ok(EncodedOutput {
@@ -1733,8 +1804,18 @@ fn encode_webp_lossless(
 fn encode_webp_lossy_bytes(image: &DynamicImage, quality: u8) -> Result<Vec<u8>, TransformError> {
     #[cfg(feature = "webp-lossy")]
     {
-        let rgba = image.to_rgba8();
-        let lossy_encoder = webp::Encoder::from_rgba(rgba.as_ref(), rgba.width(), rgba.height());
+        // Feeding libwebp an RGB buffer for an opaque image keeps the ALPH chunk out of the
+        // container, so the output does not gain an alpha channel the input never had.
+        let samples = EncodeSamples::from_image(image);
+        let (width, height) = samples.dimensions();
+        let lossy_encoder = match samples {
+            EncodeSamples::Rgb(ref buffer) => {
+                webp::Encoder::from_rgb(buffer.as_raw(), width, height)
+            }
+            EncodeSamples::Rgba(ref buffer) => {
+                webp::Encoder::from_rgba(buffer.as_raw(), width, height)
+            }
+        };
         Ok(lossy_encoder.encode(f32::from(quality)).to_vec())
     }
     #[cfg(not(feature = "webp-lossy"))]
@@ -1760,10 +1841,16 @@ fn encode_avif(
             ));
         }
         let mut bytes = Vec::new();
-        let rgba = image.to_rgba8();
+        let samples = EncodeSamples::from_image(image);
+        let (width, height) = samples.dimensions();
         let encoder = AvifEncoder::new_with_speed_quality(&mut bytes, speed, quality);
         encoder
-            .write_image(&rgba, rgba.width(), rgba.height(), ColorType::Rgba8.into())
+            .write_image(
+                samples.as_bytes(),
+                width,
+                height,
+                samples.color_type().into(),
+            )
             .map_err(|error| TransformError::EncodeFailed(error.to_string()))?;
         Ok(bytes)
     }
@@ -1778,18 +1865,30 @@ fn encode_avif(
 
 fn encode_bmp(image: &DynamicImage) -> Result<Vec<u8>, TransformError> {
     let mut bytes = Vec::new();
-    let rgba = image.to_rgba8();
+    let samples = EncodeSamples::from_image(image);
+    let (width, height) = samples.dimensions();
     image::codecs::bmp::BmpEncoder::new(&mut bytes)
-        .write_image(&rgba, rgba.width(), rgba.height(), ColorType::Rgba8.into())
+        .write_image(
+            samples.as_bytes(),
+            width,
+            height,
+            samples.color_type().into(),
+        )
         .map_err(|error: image::ImageError| TransformError::EncodeFailed(error.to_string()))?;
     Ok(bytes)
 }
 
 fn encode_tiff(image: &DynamicImage) -> Result<Vec<u8>, TransformError> {
-    let rgba = image.to_rgba8();
+    let samples = EncodeSamples::from_image(image);
+    let (width, height) = samples.dimensions();
     let mut cursor = Cursor::new(Vec::new());
     image::codecs::tiff::TiffEncoder::new(&mut cursor)
-        .write_image(&rgba, rgba.width(), rgba.height(), ColorType::Rgba8.into())
+        .write_image(
+            samples.as_bytes(),
+            width,
+            height,
+            samples.color_type().into(),
+        )
         .map_err(|error: image::ImageError| TransformError::EncodeFailed(error.to_string()))?;
     Ok(cursor.into_inner())
 }
@@ -2182,6 +2281,10 @@ fn read_input_metadata(input: &Artifact) -> Result<RetainedMetadata, TransformEr
     }
 }
 
+/// Reports whether the encoded output carries an alpha channel.
+///
+/// This mirrors the choice [`EncodeSamples::from_image`] makes, so the metadata reported by
+/// `convert` matches what `inspect` reads back from the encoded file.
 fn output_has_alpha(image: &DynamicImage, media_type: MediaType) -> bool {
     match media_type {
         MediaType::Jpeg => false,
@@ -2190,7 +2293,7 @@ fn output_has_alpha(image: &DynamicImage, media_type: MediaType) -> bool {
         | MediaType::Avif
         | MediaType::Svg
         | MediaType::Bmp
-        | MediaType::Tiff => image.color().has_alpha(),
+        | MediaType::Tiff => image_has_transparency(image),
     }
 }
 
@@ -2233,6 +2336,30 @@ mod tests {
                 has_alpha: Some(fill[3] < u8::MAX),
             },
         )
+    }
+
+    /// Builds an opaque PNG stored as PNG color type 2 (truecolor, no alpha channel).
+    fn opaque_rgb_png_artifact(width: u32, height: u32) -> Artifact {
+        let image = image::RgbImage::from_fn(width, height, |x, y| {
+            image::Rgb([(x * 8) as u8, (y * 8) as u8, 128])
+        });
+        let mut bytes = Vec::new();
+        PngEncoder::new(&mut bytes)
+            .write_image(&image, width, height, ColorType::Rgb8.into())
+            .expect("encode png");
+
+        let artifact = sniff_artifact(RawArtifact::new(bytes, None)).expect("sniff png");
+        assert_eq!(
+            artifact.metadata.has_alpha,
+            Some(false),
+            "fixture must start without an alpha channel"
+        );
+        artifact
+    }
+
+    fn encoded_png_has_alpha(bytes: &[u8]) -> bool {
+        let decoder = PngDecoder::new(Cursor::new(bytes)).expect("decode png");
+        decoder.color_type().has_alpha()
     }
 
     fn jpeg_artifact_with_metadata(
@@ -3117,6 +3244,166 @@ mod tests {
         .unwrap_err();
         assert!(matches!(err, TransformError::LimitExceeded(_)));
         assert!(err.to_string().contains("output image"));
+    }
+
+    // Regression tests for https://github.com/nao1215/truss/issues/253: every decoded image
+    // was widened to RGBA8 before encoding, so an opaque RGB PNG came back RGBA — a larger
+    // file, and a same-format pass that silently changed the color model.
+    #[test]
+    fn transform_raster_keeps_opaque_rgb_png_without_alpha() {
+        let input = opaque_rgb_png_artifact(16, 16);
+        let result = transform_raster(TransformRequest::new(
+            input,
+            TransformOptions {
+                format: Some(MediaType::Png),
+                ..TransformOptions::default()
+            },
+        ))
+        .expect("transform");
+
+        assert!(
+            !encoded_png_has_alpha(&result.artifact.bytes),
+            "a no-op same-format pass must not add an alpha channel"
+        );
+        assert_eq!(result.artifact.metadata.has_alpha, Some(false));
+        let round_tripped =
+            sniff_artifact(RawArtifact::new(result.artifact.bytes, None)).expect("sniff output");
+        assert_eq!(round_tripped.metadata.has_alpha, Some(false));
+    }
+
+    #[test]
+    fn transform_raster_keeps_opaque_rgb_png_without_alpha_after_resize() {
+        let input = opaque_rgb_png_artifact(16, 16);
+        let result = transform_raster(TransformRequest::new(
+            input,
+            TransformOptions {
+                format: Some(MediaType::Png),
+                width: Some(8),
+                ..TransformOptions::default()
+            },
+        ))
+        .expect("transform");
+
+        assert!(!encoded_png_has_alpha(&result.artifact.bytes));
+        assert_eq!(result.artifact.metadata.has_alpha, Some(false));
+    }
+
+    #[test]
+    fn transform_raster_keeps_alpha_for_a_transparent_png() {
+        let input = png_artifact(4, 4, Rgba([10, 20, 30, 128]));
+        let result = transform_raster(TransformRequest::new(
+            input,
+            TransformOptions {
+                format: Some(MediaType::Png),
+                ..TransformOptions::default()
+            },
+        ))
+        .expect("transform");
+
+        assert!(
+            encoded_png_has_alpha(&result.artifact.bytes),
+            "transparency must survive the round trip"
+        );
+        assert_eq!(result.artifact.metadata.has_alpha, Some(true));
+    }
+
+    #[test]
+    fn transform_raster_narrows_a_fully_opaque_rgba_png_to_rgb() {
+        // Dropping an all-opaque alpha channel is pixel-lossless and shrinks the output.
+        let input = png_artifact(4, 4, Rgba([10, 20, 30, 255]));
+        let result = transform_raster(TransformRequest::new(
+            input,
+            TransformOptions {
+                format: Some(MediaType::Png),
+                ..TransformOptions::default()
+            },
+        ))
+        .expect("transform");
+
+        assert!(!encoded_png_has_alpha(&result.artifact.bytes));
+        assert_eq!(result.artifact.metadata.has_alpha, Some(false));
+    }
+
+    #[test]
+    fn transform_raster_adds_alpha_when_contain_padding_is_transparent() {
+        // Padding an opaque image into a wider box with the default transparent fill is a
+        // case where the operation genuinely requires an alpha channel.
+        let input = opaque_rgb_png_artifact(8, 4);
+        let result = transform_raster(TransformRequest::new(
+            input,
+            TransformOptions {
+                format: Some(MediaType::Png),
+                width: Some(16),
+                height: Some(16),
+                fit: Some(Fit::Contain),
+                ..TransformOptions::default()
+            },
+        ))
+        .expect("transform");
+
+        assert!(encoded_png_has_alpha(&result.artifact.bytes));
+        assert_eq!(result.artifact.metadata.has_alpha, Some(true));
+    }
+
+    #[test]
+    fn transform_raster_keeps_opaque_output_when_contain_padding_is_opaque() {
+        let input = opaque_rgb_png_artifact(8, 4);
+        let result = transform_raster(TransformRequest::new(
+            input,
+            TransformOptions {
+                format: Some(MediaType::Png),
+                width: Some(16),
+                height: Some(16),
+                fit: Some(Fit::Contain),
+                background: Some(Rgba8 {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                }),
+                ..TransformOptions::default()
+            },
+        ))
+        .expect("transform");
+
+        assert!(!encoded_png_has_alpha(&result.artifact.bytes));
+        assert_eq!(result.artifact.metadata.has_alpha, Some(false));
+    }
+
+    #[test]
+    fn transform_raster_keeps_opaque_bmp_output_without_alpha() {
+        let input = opaque_rgb_png_artifact(8, 8);
+        let result = transform_raster(TransformRequest::new(
+            input,
+            TransformOptions {
+                format: Some(MediaType::Bmp),
+                ..TransformOptions::default()
+            },
+        ))
+        .expect("transform");
+
+        assert_eq!(result.artifact.metadata.has_alpha, Some(false));
+        let round_tripped =
+            sniff_artifact(RawArtifact::new(result.artifact.bytes, None)).expect("sniff output");
+        assert_eq!(round_tripped.metadata.has_alpha, Some(false));
+    }
+
+    #[test]
+    fn transform_raster_keeps_opaque_webp_output_without_alpha() {
+        let input = opaque_rgb_png_artifact(8, 8);
+        let result = transform_raster(TransformRequest::new(
+            input,
+            TransformOptions {
+                format: Some(MediaType::Webp),
+                ..TransformOptions::default()
+            },
+        ))
+        .expect("transform");
+
+        assert_eq!(result.artifact.metadata.has_alpha, Some(false));
+        let round_tripped =
+            sniff_artifact(RawArtifact::new(result.artifact.bytes, None)).expect("sniff output");
+        assert_eq!(round_tripped.metadata.has_alpha, Some(false));
     }
 
     #[test]

--- a/src/core.rs
+++ b/src/core.rs
@@ -1897,16 +1897,19 @@ fn sniff_webp_vp8l(bytes: &[u8]) -> Result<ArtifactMetadata, TransformError> {
         ));
     }
 
+    // VP8L header bits, LSB first: 14 bits width-1, 14 bits height-1, 1 bit alpha_is_used,
+    // 3 bits version.
     let bits = read_u32_le(&bytes[1..5])?;
     let width = (bits & 0x3FFF) + 1;
     let height = ((bits >> 14) & 0x3FFF) + 1;
+    let has_alpha = (bits >> 28) & 1 != 0;
 
     Ok(ArtifactMetadata {
         width: Some(width),
         height: Some(height),
         frame_count: 1,
         duration: None,
-        has_alpha: None,
+        has_alpha: Some(has_alpha),
     })
 }
 
@@ -2240,7 +2243,11 @@ mod tests {
     }
 
     fn webp_vp8l_bytes(width: u32, height: u32) -> Vec<u8> {
-        let packed = (width - 1) | ((height - 1) << 14);
+        webp_vp8l_bytes_with_alpha(width, height, false)
+    }
+
+    fn webp_vp8l_bytes_with_alpha(width: u32, height: u32, alpha_is_used: bool) -> Vec<u8> {
+        let packed = (width - 1) | ((height - 1) << 14) | (u32::from(alpha_is_used) << 28);
         let mut bytes = Vec::new();
         bytes.extend_from_slice(b"RIFF");
         bytes.extend_from_slice(&17_u32.to_le_bytes());
@@ -2711,6 +2718,18 @@ mod tests {
         assert_eq!(artifact.media_type, MediaType::Webp);
         assert_eq!(artifact.metadata.width, Some(123));
         assert_eq!(artifact.metadata.height, Some(77));
+        assert_eq!(artifact.metadata.has_alpha, Some(false));
+    }
+
+    #[test]
+    fn sniff_artifact_reads_the_webp_vp8l_alpha_bit() {
+        let artifact = sniff_artifact(RawArtifact::new(
+            webp_vp8l_bytes_with_alpha(123, 77, true),
+            None,
+        ))
+        .expect("sniff webp vp8l");
+
+        assert_eq!(artifact.metadata.has_alpha, Some(true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #253.

Every encoder called `image.to_rgba8()` and wrote `ColorType::Rgba8` unconditionally, so a decoded RGB image was always re-encoded as RGBA. A no-op `truss convert in.png -o out.png` on an opaque PNG flipped `hasAlpha` from `false` to `true` and grew the file, and the same happened through any resize.

## Changes

- Add `image_has_transparency()` (scans alpha samples) and `EncodeSamples`, which materializes RGB8 for a fully opaque image and RGBA8 otherwise.
- Route PNG, lossless WebP, lossy WebP (`webp::Encoder::from_rgb` keeps the `ALPH` chunk out), BMP, TIFF, and AVIF encoding through it. JPEG was already RGB-only.
- `output_has_alpha()` now mirrors the same decision, so the metadata `convert` reports matches what `inspect` reads back from the file.
- Dropping an all-opaque alpha channel is pixel-lossless, so the narrowing is safe in both directions: an operation that genuinely needs alpha (e.g. `--fit contain` letterboxing with the default transparent background) still gets it.
- Drive-by: `sniff_webp_vp8l` returned `has_alpha: None`, so `truss inspect` reported `"hasAlpha": null` for every lossless WebP. It now reads the `alpha_is_used` header bit.

## Tests

- Unit: opaque RGB PNG stays RGB on a no-op pass and after a resize; transparency survives; a fully opaque RGBA input narrows to RGB; `--fit contain` adds alpha for a transparent background but not for an opaque one; opaque BMP and WebP output stay opaque. Plus a `sniff_artifact` test for the VP8L alpha bit.
- E2E (atago, `e2e/atago/color_model.atago.yaml`): reproduces the issue's exact `inspect` → `convert` → `inspect` sequence against the real binary, asserting `$.hasAlpha` on both ends, atago's pixel-scanning `image: alpha:` assertion, and `similar_to` to prove the same-format pass leaves pixels untouched.