### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## Unreleased
+## v0.12.0
 
 ### Added
 
 - WebP output carries ICC, EXIF, and XMP in `ICCP`/`EXIF`/`XMP ` container chunks, lossy encoding included. libwebp embeds no metadata, so truss now writes the chunks itself, promoting the container to the extended (`VP8X`) format when needed.
+- E2E coverage (atago) for the output pixel budget, color-model preservation, and metadata retention, plus an `integration/fixtures/icc-profile.jpg` fixture carrying an embedded sRGB profile.
+
+### Changed
+
+- `--strip-metadata` now documents, in `truss help convert`/`help optimize` and the README, that lossy optimization keeps the ICC profile so colors are not shifted by the re-encode. The README also gains a per-format metadata support table.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4929,7 +4929,7 @@ dependencies = [
 
 [[package]]
 name = "truss-image"
-version = "0.11.5"
+version = "0.12.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "truss-image"
-version = "0.11.5"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.92"
 authors = ["CHIKAMATSU Naohiro <n.chika156@gmail.com>"]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Truss Image Server API
-  version: 0.11.5
+  version: 0.12.0
   description: |
     HTTP API for the Truss image toolkit.
 
@@ -499,7 +499,7 @@ paths:
               example:
                 status: ok
                 service: truss
-                version: 0.11.5
+                version: 0.12.0
                 uptimeSeconds: 3600
                 checks:
                   - name: storageRoot
@@ -562,7 +562,7 @@ paths:
               example:
                 status: ok
                 service: truss
-                version: 0.11.5
+                version: 0.12.0
         '429':
           $ref: '#/components/responses/TooManyRequests'
     head:
@@ -1424,7 +1424,7 @@ components:
         version:
           type: string
           description: Semantic version of the running binary.
-          example: "0.11.5"
+          example: "0.12.0"
     ReadinessResponse:
       type: object
       description: Readiness payload with individual dependency checks.
@@ -1453,7 +1453,7 @@ components:
         version:
           type: string
           description: Semantic version of the running binary.
-          example: "0.11.5"
+          example: "0.12.0"
         uptimeSeconds:
           type: integer
           format: int64

--- a/examples/vite-truss-wasm/package-lock.json
+++ b/examples/vite-truss-wasm/package-lock.json
@@ -19,7 +19,7 @@
     },
     "../../packages/truss-wasm": {
       "name": "@nao1215/truss-wasm",
-      "version": "0.11.5",
+      "version": "0.12.0",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/packages/truss-url-signer/package.json
+++ b/packages/truss-url-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nao1215/truss-url-signer",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "Official Node.js/TypeScript signer for truss public image URLs.",
   "type": "module",
   "main": "./index.js",

--- a/packages/truss-wasm/package.json
+++ b/packages/truss-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nao1215/truss-wasm",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "Official bundler-ready Wasm package for truss image transforms.",
   "type": "module",
   "main": "./dist/truss.js",


### PR DESCRIPTION
## Summary

Release PR for **v0.12.0**. Minor bump: the release fixes three reported bugs, one of which changes user-visible output (color model) and one of which adds a capability (WebP metadata chunks).

Closes #252, #253, #279 (already merged; this PR only carries the release metadata).

## Version metadata

- `Cargo.toml` / `Cargo.lock`: 0.11.5 → 0.12.0
- `packages/truss-wasm`, `packages/truss-url-signer`: 0.11.5 → 0.12.0
- `examples/vite-truss-wasm/package-lock.json`, `docs/openapi.yaml`
- `CHANGELOG.md`: `Unreleased` → `v0.12.0`

## What is in this release

**Fixed**

- **#252** — `MAX_OUTPUT_PIXELS` was checked against the *source* size for whichever axis the user omitted, so `--width 10000` on a small image produced a 100-megapixel output with exit 0, and a large enough single dimension stalled allocating the buffer. The limit now runs against the aspect-scaled output size.
- **#253** — every decoded image was widened to RGBA8 before encoding, so a no-op `truss convert in.png -o out.png` flipped `hasAlpha` from `false` to `true` and grew the file. PNG, WebP, BMP, TIFF, and AVIF output now pick RGB when the pixels are fully opaque. Also fixes `inspect` reporting `"hasAlpha": null` for lossless WebP.
- **#279** — `optimize --format webp --mode lossy` failed on every ICC-bearing input with no working flag combination, because a strip request is upgraded to "preserve ICC" for lossy output and the encoder rejected any retained metadata. truss now writes the `ICCP`/`EXIF`/`XMP ` chunks into the container itself.

**Added**

- WebP metadata chunk support for both lossy and lossless output.
- atago E2E suites for the pixel budget, color-model preservation, and metadata retention, plus an ICC-bearing JPEG fixture.

## Verification

- `cargo test --all-features --all-targets`, `--doc`, `clippy -D warnings`, `fmt --check`: all green.
- `e2e/run.sh`: 112 atago scenarios pass against the release binary.
- `cargo publish --locked --dry-run`: packages cleanly at 0.12.0.
- `npm run check:version` in `packages/truss-url-signer`: crate and package versions agree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebP metadata preservation now supports ICC, EXIF, and XMP data, including extended-container images.
  * Updated lossy optimization behavior preserves ICC metadata when applicable.
  * Added documentation describing format-specific metadata support and stripping behavior.

* **Chores**
  * Released version 0.12.0 across the application and related packages.
  * Updated API documentation and health responses to reflect the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->