### PR TITLE
chore(ci): bump atago to v0.20.0

### DIFF
--- a/.github/workflows/integration-cli.yml
+++ b/.github/workflows/integration-cli.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.17.0
+          version: v0.20.0
 
       # e2e/run.sh builds truss (cargo build --release --locked) and runs the
       # atago specs in e2e/atago against the freshly built binary.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build](https://github.com/nao1215/truss/actions/workflows/rust.yml/badge.svg)](https://github.com/nao1215/truss/actions/workflows/rust.yml)
 [![CLI Integration](https://github.com/nao1215/truss/actions/workflows/integration-cli.yml/badge.svg)](https://github.com/nao1215/truss/actions/workflows/integration-cli.yml)
+[![tested with atago](https://img.shields.io/badge/tested%20with-atago-7c3aed?logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI%2BPHBhdGggZmlsbD0iI2ZmZiIgZD0iTTMuNiA0LjIgMTEuOSAxMmwtOC4zIDcuOC0xLjktMi4yTDcuOSAxMiAxLjcgNi40eiIvPjxyZWN0IGZpbGw9IiNmZmYiIHg9IjEyLjYiIHk9IjE3LjIiIHdpZHRoPSI5LjciIGhlaWdodD0iMi44IiByeD0iMS40Ii8%2BPC9zdmc%2B&logoColor=white)](https://github.com/nao1215/atago)
 [![API Integration](https://github.com/nao1215/truss/actions/workflows/integration.yml/badge.svg)](https://github.com/nao1215/truss/actions/workflows/integration.yml)
 [![Crates.io](https://img.shields.io/crates/v/truss-image)](https://crates.io/crates/truss-image)
 [![Crates.io Downloads](https://img.shields.io/crates/d/truss-image)](https://crates.io/crates/truss-image)


### PR DESCRIPTION
## Summary

Move the pinned atago used by the CLI integration workflow from v0.17.0 to v0.20.0, and add a tested-with-atago badge to the README.

Three releases. Two entries could matter to a suite:

- v0.18.0: a flaky scenario — one that failed and then passed on a re-run, or that failed some `--repeat` iterations — now fails the run instead of exiting 0. e2e/run.sh passes neither flag, so nothing changes.
- v0.19.0: a flag written after the spec paths is read as a flag rather than as a spec path, and `--fail-fast` stops for every outcome that fails the run.

All 112 scenarios pass locally on v0.20.0 with no spec changes.

## Related Issues

## Test Plan
- [ ] Unit tests added/updated
- [x] `cargo test` passes locally
- [x] `cargo clippy` clean

## Checklist
- [x] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if applicable)

